### PR TITLE
fix(client): fixing check-all bug on blip-table

### DIFF
--- a/src/components/blipTable/blipTable.component.ts
+++ b/src/components/blipTable/blipTable.component.ts
@@ -49,6 +49,8 @@ export class BlipTableController {
             this.$scope.$watch('$ctrl.selected.length', (newVal: number) => {
                 if (newVal && newVal === this.tableData.length) {
                     this.allChecked = true;
+                } else if (newVal === 0) {
+                    this.allChecked = false;
                 }
             });
         }


### PR DESCRIPTION
The check-all for table was not working when all items went unchecked