### PR TITLE
#170922 - fix: close first element opened when click on other

### DIFF
--- a/src/components/expandableList/expandableItem/index.ts
+++ b/src/components/expandableList/expandableItem/index.ts
@@ -21,6 +21,10 @@ export class ExpandableItemComponent {
         this.isActive = !this.isActive;
     }
 
+    deactivate() {
+        this.isActive = false;
+    }
+
     open(event) {
         this.toggleActive();
         this.expandableListCtrl.toggleItem(this);

--- a/src/components/expandableList/expandableList.component.ts
+++ b/src/components/expandableList/expandableList.component.ts
@@ -18,7 +18,7 @@ export class ExpandableListComponent {
             this.previousActivated = undefined;
             return;
         }
-        this.previousActivated && this.previousActivated.toggleActive();
+        this.previousActivated && this.previousActivated.deactivate();
         this.previousActivated = item;
     }
 }


### PR DESCRIPTION
Close the first element opened when click on other. Needed on UserDetailView on Blip Portal.