### PR TITLE
fix: asign messageCardContent at analysisInfo's onInit

### DIFF
--- a/src/components/analysisInfo/analysisInfo.component.ts
+++ b/src/components/analysisInfo/analysisInfo.component.ts
@@ -24,14 +24,7 @@ class AnalysisInfoController extends ComponentController {
     public structuredIntents: { label: string, value: string }[];
     public displayEntityContent: boolean = false;
     public displayHiddencontent: boolean = false;
-
-    public messageCardContent: any = {
-        document: {
-            type: 'text/plain',
-            content: this.analysis.content,
-        },
-        position: 'right'
-    };
+    public messageCardContent: any = {};
 
     public onEntityToggle: (toggle: object) => void;
     public onError: (id: object) => void;
@@ -49,6 +42,14 @@ class AnalysisInfoController extends ComponentController {
     async $onInit() {
 
         this.scrollTo();
+
+        this.messageCardContent = {
+            document: {
+                type: 'text/plain',
+                content: this.analysis.content,
+            },
+            position: 'right'
+        };
 
         try  {
 
@@ -146,18 +147,6 @@ class AnalysisInfoController extends ComponentController {
             }));
 
         });
-
-        this.messageCardContent = undefined;
-        setTimeout(() => {
-            this.messageCardContent = {
-                document: {
-                    type: 'text/plain',
-                    content: content,
-                },
-                position: 'right'
-            };
-        }, 0);
-
     }
 
     scrollTo() {


### PR DESCRIPTION
Essa demanda #381955, visa corrigir o bug que a atualização do Angular casou(1.5 -> 1.8) na aplicação de IA.

Ao tentar testar o de IA, o seguinte erro ocorria: 
![image](https://user-images.githubusercontent.com/39316466/196489785-c8e4cf07-06a8-4131-8430-c6f83c7fb96a.png)

Isso porque com o Angular 1.8 tenta atribuir as bindings antes do build. Como dito na documentação de migração: https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$compile

Colocamos então a atribuição dentro do onInit, assim trazendo a normalidade à aplicação de IA.

![image](https://user-images.githubusercontent.com/39316466/196490268-89a05f71-8e2e-404e-b354-4eca0ed56cbc.png)
 