### PR TITLE
fix(overview): fix-morevertical-icon-not-visible

### DIFF
--- a/src/components/icon/lib/morevertical-icon.svg
+++ b/src/components/icon/lib/morevertical-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24"><g fill="none" stroke="#8ca0b3" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/></g></svg>


### PR DESCRIPTION
fix bug that not showing icon morevertical-icon in overview on blip portal