### PR TITLE
feat(components): fixing variables in component index of sidenavmenuitem

### DIFF
--- a/src/components/sidenavMenuItem/index.ts
+++ b/src/components/sidenavMenuItem/index.ts
@@ -9,6 +9,8 @@ export const sidenavMenuItem = angular
     .component('sidenavMenuItem', {
         template: template,
         controller: class {
+            title: any;
+            text: any;
             sparams: any;
             sref: any;
             icon: any;
@@ -26,13 +28,11 @@ export const sidenavMenuItem = angular
                 private $state,
                 private $element,
                 private $rootScope,
-                private AccountService,
             ) {
                 'ngInject';
                 this.$rootScope = $rootScope;
                 this.$state = $state;
                 this.$element = $element;
-                this.AccountService = AccountService;
                 this.hasChildren = this.hasChildren || false;
                 this.preventDefault = this.preventDefault == false ? false : true;
                 this._isNewChildren = false;


### PR DESCRIPTION
When doing a code refactoring in the portal blip project, the AccountService. Therefore, when trying to use the sidenav-menu-item component, an instantiation error is returned.
![image](https://user-images.githubusercontent.com/62907295/236488100-7df29dd5-d508-4b65-8dff-90817b389388.png)
